### PR TITLE
Added FlexibleContexts extension to Images.hsc to make it compile wit…

### DIFF
--- a/Graphics/Transform/Magick/Images.hsc
+++ b/Graphics/Transform/Magick/Images.hsc
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 module Graphics.Transform.Magick.Images(initializeMagick, readImage, writeImage, pingImage,
               readInlineImage,
               getFilename,


### PR DESCRIPTION
…h GHC 7.10.3 on OS X El Capitan.
I had to add this to compile hsmagick. There were also a bunch of warnings issued which I did not 
follow.
